### PR TITLE
Accept smtp_settings

### DIFF
--- a/README
+++ b/README
@@ -55,6 +55,19 @@ There are four special headers that simple_mailer processes:
 
 All other headers are used verbatim in the message.
 
+== Configuration
+
+You can pass in options just like with the Mail gem.
+
+  SimpleMailer.smtp_settings.update(
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :domain => "localhost",
+    :user_name => "bob",
+    :password => "secret",
+    :authentication => :plain,
+  )
+
 == Testing
 
 Testing support is probably the main reason to use simple_mailer over


### PR DESCRIPTION
I really like how thin the SimpleMailer is, and it made me realize how easy it is to actually use Net::STMP. I want to use it instead of Mail gem, because Mail gem is heavy, and I only need plain text emails for my application.

I was really missing SMTP settings configuration on SimpleMailer, I don't know how you actually send emails without it. So I added almost the same one as the Mail gem (without some needless method checking, I guess for Ruby 1.8.3).

I didn't really know how to test this properly, I don't know if it's necessary. I don't really know how to write RSpec tests to be compatible with all versions of RSpec, so I was thinking I could leave it to you :). I can successfully send an email with this commit.
