### PR TITLE
Add net-smtp dependency for Ruby 3.1+

### DIFF
--- a/simple_mailer.gemspec
+++ b/simple_mailer.gemspec
@@ -9,5 +9,6 @@ spec = Gem::Specification.new do |s|
   s.extra_rdoc_files = ["MIT-LICENSE"]
   s.require_paths = ["lib"]
   s.rdoc_options = %w'--inline-source --line-numbers README lib'
+  s.add_dependency "net-smtp"
   s.add_development_dependency "minitest-global_expectations"
 end


### PR DESCRIPTION
To avoids this:

  warning: net/smtp was loaded from the standard library, but is not part of the default gems starting from Ruby 3.1.0.
  You can add net-smtp to your Gemfile or gemspec to silence this warning.

This change seems to have no ill effects on a Ruby 2.5 installation I had handy, but I'm not completely sure what effect this will have on those using ancient Ruby.